### PR TITLE
Update PallyPowerLiteValues.lua

### DIFF
--- a/PallyPowerLiteValues.lua
+++ b/PallyPowerLiteValues.lua
@@ -1,3 +1,5 @@
+L = {}
+L["PallyPower Lite"] = "PallyPower Lite"
 
 PallyPowerLite.commPrefix = "PLPWRL"
 PallyPowerLite.pallyDataTemplate = {


### PR DESCRIPTION
Hello!

When i updated the addon i remember i got some errors from patch 4.4.1 and i did this to resolve it.

This is the errors.

Message: ...rface/AddOns/PallyPowerLite/PallyPowerLiteValues.lua:129: attempt to index global 'L' (a nil value)
Time: Sat Mar  1 17:13:07 2025
Count: 1
Stack: ...rface/AddOns/PallyPowerLite/PallyPowerLiteValues.lua:129: attempt to index global 'L' (a nil value)

Locals: 

Message: Interface/AddOns/PallyPowerLite/PallyPowerLite.lua:113: attempt to concatenate global 'PALLYPOWERLIGHT_NAME' (a nil value)
Time: Sat Mar  1 17:13:07 2025
Count: 1
Stack: Interface/AddOns/PallyPowerLite/PallyPowerLite.lua:113: attempt to concatenate global 'PALLYPOWERLIGHT_NAME' (a nil value)
[string "@Interface/AddOns/Accountant_Classic/Libs/AceAddon-3.0/AceAddon-3.0.lua"]:494: in function `InitializeAddon'
[string "@Interface/AddOns/Accountant_Classic/Libs/AceAddon-3.0/AceAddon-3.0.lua"]:619: in function <...ccountant_Classic/Libs/AceAddon-3.0/AceAddon-3.0.lua:611>

Locals: self = <table> {
 initializequeue = <table> {
 }
 statuses = <table> {
 }
 embeds = <table> {
 }
 frame = AceAddon30Frame {
 }
 addons = <table> {
 }
 enablequeue = <table> {
 }
}
addon = <table> {
 modules = <table> {
 }
 baseName = "PallyPowerLite"
 defaultModuleState = true
 pallyDataTemplate = <table> {
 }
 enabledState = true
 Buffs = <table> {
 }
 LDB = <table> {
 }
 defaultModuleLibraries = <table> {
 }
 MinimapIcon = <table> {
 }
 prof = <table> {
 }
 BuffsIcons = <table> {
 }
 db = <table> {
 }
 options = <table> {
 }
 SealsIcons = <table> {
 }
 name = "PallyPowerLite"
 orderedModules = <table> {
 }
 AurasIcons = <table> {
 }
 RoleIconCoords = <table> {
 }
 ClassIcons = <table> {
 }
 ClassID = <table> {
 }
 commPrefix = "PLPWRL"
 Auras = <table> {
 }
 ClassToID = <table> {
 }
 Seals = <table> {
 }
}